### PR TITLE
fixed single recipe page recipe title text alignment

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -326,6 +326,7 @@ body {
 
 #recipe-title {
     font-size: 3rem;
+    text-align: center;
 }
 
 #recipe-text {


### PR DESCRIPTION
Minor fix on the recipe title's text alignment on the single-recipe page